### PR TITLE
fix: (button): fixing clock to have 1 for button and 1 for movement

### DIFF
--- a/src/actions/play.c
+++ b/src/actions/play.c
@@ -9,9 +9,7 @@
 
 int do_play(frame_t *frame)
 {
-    if (frame->ui->scene == MAINMENU) {
-        frame->ui->scene = GAME;
-        frame->game->level = 1;
-    }
+    frame->ui->scene = GAME;
+    frame->game->level = 1;
     return 0;
 }

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -38,15 +38,15 @@ static int init_images(frame_t *frame)
 static int init_clocks(frame_t *frame)
 {
     int result = 0;
-    int nbclocks = 1;
+    int nbclocks = 5;
 
-    frame->clock = malloc(sizeof(clocks_t) * nbclocks);
-    if (!frame->clock)
+    CLOCK = malloc(sizeof(clocks_t) * nbclocks);
+    if (!CLOCK)
         return 84;
     frame->nb_clocks = nbclocks;
     for (int i = 0; i < nbclocks; i++)
         result += create_clock(frame, i);
-    if (result > 0)
+    if (result != 0)
         return 84;
     return 0;
 }

--- a/src/scenes/game.c
+++ b/src/scenes/game.c
@@ -9,7 +9,7 @@
 
 int game(frame_t *frame)
 {
-    update_player(PLAYER, &frame->clock[0]);
+    update_player(PLAYER, &(frame->clock[1]));
     draw_floor_and_ceiling(WINDOW);
     cast_all_rays(frame);
     return 0;

--- a/src/scenes/scenes_manager.c
+++ b/src/scenes/scenes_manager.c
@@ -9,14 +9,16 @@
 
 int scene_manager(frame_t *frame)
 {
-    draw_all(frame);
     switch (UI->scene) {
         case MAINMENU:
-            return mainmenu(frame);
+            mainmenu(frame);
+            break;
         case GAME:
-            return game(frame);
+            game(frame);
+            break;
         default:
             break;
     }
+    draw_all(frame);
     return 0;
 }


### PR DESCRIPTION
This pull request includes several changes to improve the game's initialization and scene management logic. The most important changes include modifying the scene transitions, adjusting the initialization of clocks, and updating player handling in the game scene.

Scene management improvements:

* [`src/scenes/scenes_manager.c`](diffhunk://#diff-4a9546aa16a0fb01f34b4ac14b4d1123ac83ac8a3ab6b4fc0f5b88f4c6e2b788L12-R22): Changed the `scene_manager` function to use `break` statements instead of `return` for transitioning between scenes, ensuring `draw_all` is called after scene updates.

Initialization adjustments:

* [`src/init/init.c`](diffhunk://#diff-95ae2da1263c16eb905d0632f888a2ce21c06478d313ca835f2a2e9256202b0dL41-R49): Updated `init_clocks` to allocate memory for five clocks instead of one and adjusted the error handling logic.

Gameplay adjustments:

* [`src/actions/play.c`](diffhunk://#diff-a2d51734138b659565b5170ba6d9ab15de1f0d5650bc50d565e95132ca45e02dL12-L15): Removed the condition that checked if the scene was `MAINMENU` before setting it to `GAME` and initializing the game level.
* [`src/scenes/game.c`](diffhunk://#diff-01468cafe50f441d297ec3ec6554da9eb914fb9bf45d8c310a96cd553127f8ccL12-R12): Modified the `game` function to update the player using the second clock instead of the first.