### PR TITLE
fix (raycast): fixing wall draw with raycasting and textures

### DIFF
--- a/includes/frame.h
+++ b/includes/frame.h
@@ -254,9 +254,9 @@ double view_angle(float angle);
 void draw_floor_and_ceiling(sfRenderWindow *window);
 void render_wall_column(sfRenderWindow *window, int column,
     float wall_height, sfColor color);
-void render_textured_wall_column(sfRenderWindow *window, int column,
-    float wall_height, sfTexture *texture);
 void cast_all_rays(frame_t *frame);
+void render_wall_column_textured(frame_t *frame, sfVector2f column_wall_height,
+    sfVector2f hits, bool hit_vertical);
 
 //PLAYER
 void update_player(player_t *player, clocks_t *clock);

--- a/src/raycast/drawer.c
+++ b/src/raycast/drawer.c
@@ -41,19 +41,27 @@ void render_wall_column(sfRenderWindow *window, int column,
     sfRectangleShape_destroy(wall_rect);
 }
 
-void render_textured_wall_column(sfRenderWindow *window, int column,
-    float wall_height, sfTexture *texture)
+void render_wall_column_textured(frame_t *frame, sfVector2f column_wall_height,
+    sfVector2f hits, bool hit_vertical)
 {
-    sfRectangleShape *wall_rect = sfRectangleShape_create();
-    sfVector2f position = {(float)column, (WINDOWY - wall_height) / 2};
-    sfVector2u tex_size = sfTexture_getSize(texture);
-    int tex_x = column % tex_size.x;
-    sfIntRect texture_rect = {tex_x, 0, 1, tex_size.y};
+    int tex_x = 0;
+    float scale_y = 0;
+    sfSprite *wall_sprite = sfSprite_create();
+    sfVector2u tex_size = sfTexture_getSize(frame->game->map->walltexture);
+    sfIntRect tex_rect = {0, 0, 1, (int)tex_size.y};
 
-    sfRectangleShape_setTexture(wall_rect, texture, sfTrue);
-    sfRectangleShape_setTextureRect(wall_rect, texture_rect);
-    sfRectangleShape_setPosition(wall_rect, position);
-    sfRectangleShape_setSize(wall_rect, (sfVector2f){1, wall_height});
-    sfRenderWindow_drawRectangleShape(window, wall_rect, NULL);
-    sfRectangleShape_destroy(wall_rect);
+    sfSprite_setTexture(wall_sprite, frame->game->map->walltexture, sfTrue);
+    if (hit_vertical)
+        tex_x = (int)fmodf(hits.y, TILE_SIZE);
+    else
+        tex_x = (int)fmodf(hits.x, TILE_SIZE);
+    tex_x = tex_x * tex_size.x / TILE_SIZE;
+    tex_rect = irct(tex_x, 0, 1, (int)tex_size.y);
+    sfSprite_setTextureRect(wall_sprite, tex_rect);
+    sfSprite_setPosition(wall_sprite, v2f((float)column_wall_height.x,
+        (WINDOWY - column_wall_height.y) / 2));
+    scale_y = column_wall_height.y / (float)tex_size.y;
+    sfSprite_setScale(wall_sprite, v2f(1.0f, scale_y));
+    sfRenderWindow_drawSprite(WINDOW, wall_sprite, NULL);
+    sfSprite_destroy(wall_sprite);
 }


### PR DESCRIPTION
This pull request includes significant changes to the raycasting rendering logic, particularly related to textured wall rendering and wall hit detection. The most important changes include renaming and modifying the `render_textured_wall_column` function, adding a new function to determine if a wall hit is vertical, and updating the raycasting logic to use these new functionalities.

### Improvements to textured wall rendering:

* [`includes/frame.h`](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cL257-R259): Renamed `render_textured_wall_column` to `render_wall_column_textured` and updated its parameters to include `frame`, `column_wall_height`, `hits`, and `hit_vertical`.
* [`src/raycast/drawer.c`](diffhunk://#diff-f1972c05ba1a0c3e4748324403092788cd83d1987f28ba3225476f77442db32eL44-R66): Implemented the new `render_wall_column_textured` function, which uses `sfSprite` instead of `sfRectangleShape` for rendering and calculates texture coordinates based on whether the wall hit is vertical or not.

### Enhancements to wall hit detection:

* [`src/raycast/raycasting.c`](diffhunk://#diff-2aff993ae311e58229014f5df8c02a34782e1e711b833f87b23a6e598bebc7f7R29-R59): Added a new function `is_wall_vertical` to determine if a wall hit is vertical based on the ray position.

### Updates to raycasting logic:

* [`src/raycast/raycasting.c`](diffhunk://#diff-2aff993ae311e58229014f5df8c02a34782e1e711b833f87b23a6e598bebc7f7R29-R59): Modified the `draw_wall_cols` function to include `ray_pos` as a parameter and use the new `is_wall_vertical` function to determine the wall hit orientation. Updated the function call to `render_wall_column_textured` with the new parameters. [[1]](diffhunk://#diff-2aff993ae311e58229014f5df8c02a34782e1e711b833f87b23a6e598bebc7f7R29-R59) [[2]](diffhunk://#diff-2aff993ae311e58229014f5df8c02a34782e1e711b833f87b23a6e598bebc7f7L52-R75)