### PR TITLE
fix (raycast - obstcale): function to detecte wall changed to functio…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ SRC	=	includes/inititliser.c \
         $(FRAME_DIR)handle_event.c \
         $(FRAME_DIR)mousepos.c \
         $(FRAME_DIR)resize_event.c \
-        $(RAYCAST_DIR)wall.c \
+        $(RAYCAST_DIR)obstacle.c \
         $(RAYCAST_DIR)drawer.c \
         $(RAYCAST_DIR)raycasting.c \
         $(RAYCAST_DIR)item.c \

--- a/includes/frame.h
+++ b/includes/frame.h
@@ -268,7 +268,7 @@ int mainmenu(frame_t *frame);
 int game(frame_t *frame);
 
 //RAYCAST
-int is_wall(int x, int y);
+int is_osbtacle(int x, int y);
 double view_angle(float angle);
 void draw_floor_and_ceiling(sfRenderWindow *window);
 void render_wall_column(sfRenderWindow *window, int column,

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -19,11 +19,11 @@ float get_delta_time(clocks_t *clock)
 
 static bool get_axis_collision(sfVector2f apos, sfVector2f bpos)
 {
-    return is_wall(apos.x, bpos.y) ||
-    is_wall(apos.x + 10, bpos.y + 10) ||
-    is_wall(apos.x - 10, bpos.y - 10) ||
-    is_wall(apos.x - 10, bpos.y + 10) ||
-    is_wall(apos.x + 10, bpos.y - 10);
+    return is_osbtacle(apos.x, bpos.y) != 0 ||
+    is_osbtacle(apos.x + 10, bpos.y + 10) != 0 ||
+    is_osbtacle(apos.x - 10, bpos.y - 10) != 0 ||
+    is_osbtacle(apos.x - 10, bpos.y + 10) != 0 ||
+    is_osbtacle(apos.x + 10, bpos.y - 10) != 0;
 }
 
 static sfVector2i check_collisions(sfVector2f new_pos, sfVector2f old_pos)

--- a/src/raycast/obstacle.c
+++ b/src/raycast/obstacle.c
@@ -7,12 +7,12 @@
 
 #include "frame.h"
 
-int is_wall(int x, int y)
+int is_osbtacle(int x, int y)
 {
     int x_pos = x / TILE_SIZE;
     int y_pos = y / TILE_SIZE;
 
     if (x_pos < 0 || x_pos >= MAP_WIDTH || y_pos < 0 || y_pos >= MAP_HEIGHT)
         return 0;
-    return map[y_pos][x_pos] == WALL;
+    return map[y_pos][x_pos];
 }

--- a/src/raycast/raycasting.c
+++ b/src/raycast/raycasting.c
@@ -70,7 +70,7 @@ float cast_single_ray(float ray_angle, frame_t *frame)
     while (ray_length < 1000) {
         ray_pos.x += ray_dir.x * ray_step;
         ray_pos.y += ray_dir.y * ray_step;
-        if (is_wall(ray_pos.x, ray_pos.y)) {
+        if (is_osbtacle(ray_pos.x, ray_pos.y) == WALL) {
             corrected_dist = ray_length * cos(ray_angle - PLAYER->angle);
             draw_wall_cols(frame, corrected_dist, ray_angle, ray_pos);
             return corrected_dist;


### PR DESCRIPTION
This pull request includes several changes to the raycasting functionality of the project. The main focus is renaming the `is_wall` function to `is_osbtacle` and updating relevant references throughout the codebase. Additionally, a file was renamed to better reflect its purpose.

### Function Renaming:

* [`includes/frame.h`](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cL271-R271): Renamed the function `is_wall` to `is_osbtacle` to better reflect its purpose.
* [`src/raycast/obstacle.c`](diffhunk://#diff-231976c8c496967f2f7b627a4ff007f4df47de8146f7eee9a2820dae48ee98f4L10-R17): Updated the function definition from `is_wall` to `is_osbtacle` and modified the return condition to remove the specific check for `WALL`.

### File Renaming:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L44-R44): Renamed the file reference from `wall.c` to `obstacle.c` to align with the updated function name.

### Code Updates:

* [`src/player/player.c`](diffhunk://#diff-ef3ea37015f46bb4a00b5a8e785cfa0ec290e871a51fab46da056540ef43573dL22-R26): Updated all calls to `is_wall` to `is_osbtacle` and added a non-zero check to the return values.
* [`src/raycast/raycasting.c`](diffhunk://#diff-2aff993ae311e58229014f5df8c02a34782e1e711b833f87b23a6e598bebc7f7L73-R73): Modified the condition to check for `WALL` within the `is_osbtacle` function call.…n that return the type of the tile in the pos