### PR TITLE
fix (item - pos): fixing position calculation with celling

### DIFF
--- a/includes/inititliser.c
+++ b/includes/inititliser.c
@@ -8,7 +8,7 @@
 #include "frame.h"
 
 const struct item_infos_s ITEM_INFOS[] = {
-    {RES "lamp.png", {1, 1}, {250, 250, 10}},
+    {RES "lamp.png", {0.7, 0.7}, {250, 250, 20}},
     {NULL, {0, 0}, {0, 0, 0}}
 };
 

--- a/src/raycast/item.c
+++ b/src/raycast/item.c
@@ -25,20 +25,20 @@ static void calculate_item_position(frame_t *frame, sfVector3f itempos,
 }
 
 static void calculate_item_dimensions(item_render_data_t *data,
-    sfVector2f scale, player_t *player)
+    sfVector2f scale, player_t *player, sfVector3f itempos)
 {
-    data->projected_height = TILE_SIZE * WINDOWY / data->distance * scale.y;
-    data->scale_factor = data->projected_height
-        / (float)data->tex_size.y;
-    data->sprite_width = (float)data->tex_size.x
-        * data->scale_factor * scale.x;
+    float perp_distance = data->distance * cosf(data->rel_angle);
+
+    data->projected_height = TILE_SIZE * WINDOWY / perp_distance * scale.y;
+    data->scale_factor = data->projected_height / (float)data->tex_size.y;
+    data->sprite_width = (float)data->tex_size.x *
+        data->scale_factor * scale.x;
     data->sprite_height = data->tex_size.y * data->scale_factor * scale.y;
     data->sprite_start_x = data->screen_x - data->sprite_width / 2;
     data->sprite_end_x = data->screen_x + data->sprite_width / 2;
-    data->vertical_offset = WINDOWY / 2 - data->projected_height;
+    data->vertical_offset = WINDOWY / 2 - data->projected_height / 2;
     data->vertical_offset += (int)(WINDOWY * tanf(player->vertical_angle) / 2);
-    data->vertical_offset -= (data->ceiling_height * WINDOWY)
-        / (data->distance * 4);
+    data->vertical_offset -= (itempos.z * TILE_SIZE) / perp_distance;
 }
 
 static void render_item_columns(frame_t *frame, sfTexture *item_texture,
@@ -70,6 +70,8 @@ void draw_item(frame_t *frame, sfVector3f itempos,
     item_render_data_t data = {0};
 
     calculate_item_position(frame, itempos, item_texture, &data);
-    calculate_item_dimensions(&data, scale, PLAYER);
+    calculate_item_dimensions(&data, scale, PLAYER, itempos);
+    if (data.distance > 1000.0f)
+        return;
     render_item_columns(frame, item_texture, &data, scale);
 }

--- a/src/raycast/raycasting.c
+++ b/src/raycast/raycasting.c
@@ -63,7 +63,7 @@ static void draw_wall_cols(frame_t *frame,
 float cast_single_ray(float ray_angle, frame_t *frame)
 {
     float ray_length = 0;
-    float ray_step = 0.1;
+    float ray_step = 0.5f;
     sfVector2f ray_dir = {cos(ray_angle), sin(ray_angle)};
     sfVector2f ray_pos = PLAYER->pos;
     float corrected_dist = 0;


### PR DESCRIPTION
This pull request includes updates to improve item rendering and raycasting in the game engine. The most important changes focus on enhancing the visual scaling and positioning of items, optimizing distance calculations, and adjusting raycasting precision.

### Item Rendering Improvements:
* [`includes/inititliser.c`](diffhunk://#diff-ffe0f8717fd75a777e50621793a924c31e9447d27dfdf1b51a3e7a975be644bdL11-R11): Updated the default scale of the lamp sprite from `{1, 1}` to `{0.7, 0.7}` and increased its z-coordinate from `10` to `20` for better visual consistency and positioning.
* [`src/raycast/item.c`](diffhunk://#diff-a252b682ed668d457ece42235f4da315bc7474918fb683ecb5f7e1f4d8ba48aeL28-R41): Modified `calculate_item_dimensions` to use perpendicular distance (`perp_distance`) for more accurate scaling and adjusted vertical offsets to account for item height (`itempos.z`).
* [`src/raycast/item.c`](diffhunk://#diff-a252b682ed668d457ece42235f4da315bc7474918fb683ecb5f7e1f4d8ba48aeL73-R75): Added a distance check in `draw_item` to skip rendering items farther than `1000.0f` units, improving performance by avoiding unnecessary rendering.

### Raycasting Optimization:
* [`src/raycast/raycasting.c`](diffhunk://#diff-2aff993ae311e58229014f5df8c02a34782e1e711b833f87b23a6e598bebc7f7L66-R66): Increased the `ray_step` size from `0.1` to `0.5f` in `cast_single_ray` to improve raycasting efficiency, reducing the number of iterations for each ray.