### PR TITLE
feat (item - rec): adding a possibility of adding a rect to an item

### DIFF
--- a/includes/frame.h
+++ b/includes/frame.h
@@ -188,6 +188,7 @@ typedef struct item_s {
     sfVector3f pos;
     sfTexture *texture;
     sfVector2f scale;
+    sfIntRect rec;
 } item_t;
 
 typedef struct enemy_s {

--- a/includes/inititliser.c
+++ b/includes/inititliser.c
@@ -8,8 +8,8 @@
 #include "frame.h"
 
 const struct item_infos_s ITEM_INFOS[] = {
-    {RES "lamp.png", {1, 1}, {250, 250, 10}},
-    {NULL, {0, 0}, {0, 0, 0}}
+    {RES "lamp.png", {0.7, 0.7}, {250, 250, 20}, {-1, -1, -1, -1}},
+    {NULL, {0, 0}, {0, 0, 0}, {-1, -1, -1, -1}}
 };
 
 const struct enemy_infos_s ENEMY_INFOS[] = {

--- a/includes/item.h
+++ b/includes/item.h
@@ -14,6 +14,7 @@ struct item_infos_s {
     char *path;
     sfVector2f scale;
     sfVector3f pos;
+    sfIntRect rec;
 };
 
 extern const struct item_infos_s ITEM_INFOS[];

--- a/src/init/init_game.c
+++ b/src/init/init_game.c
@@ -37,9 +37,11 @@ static int init_items(frame_t *frame)
     int result = 0;
 
     NBITEMS = 0;
-    for (int i = 0; ITEM_INFOS[i].path; i++)
+    for (int i = 0; ITEM_INFOS[i].path; i++) {
         result += create_item(frame, ITEM_INFOS[i].path,
             ITEM_INFOS[i].scale, ITEM_INFOS[i].pos);
+        ITEM[NBITEMS - 1].rec = ITEM_INFOS[i].rec;
+    }
     if (result != 0)
         return 84;
     return 0;


### PR DESCRIPTION
This pull request introduces a new `sfIntRect rec` field to the `item_t` and `item_infos_s` structures, updates related initializations, and ensures the new field is properly set during item creation. These changes enhance the flexibility of item management by allowing rectangular regions to be associated with items.

### Structural Changes:

* [`includes/frame.h`](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cR191): Added a new `sfIntRect rec` field to the `item_t` structure to store rectangular region information.
* [`includes/item.h`](diffhunk://#diff-455b163d550f8936c8714368ee956009aefec6daf3383ee848dcd7c97bf8f0c5R17): Added a new `sfIntRect rec` field to the `item_infos_s` structure to support initialization of the new `rec` field in `item_t`.

### Initialization Updates:

* [`includes/inititliser.c`](diffhunk://#diff-ffe0f8717fd75a777e50621793a924c31e9447d27dfdf1b51a3e7a975be644bdL11-R12): Updated the `ITEM_INFOS` array to include initialization values for the new `rec` field. Default values of `{-1, -1, -1, -1}` are used for uninitialized items.

### Logic Updates:

* [`src/init/init_game.c`](diffhunk://#diff-ca2e5107f360fdc79768854a394f312c9d3cd5cfe9eb40d4bf5c867b4165b363L40-R44): Modified the `init_items` function to assign the `rec` field from `ITEM_INFOS` to the corresponding `item_t` during item creation.