### PR TITLE
fix (raycast opti) : optimized ceiling and floor raycast to a max dist

### DIFF
--- a/includes/frame.h
+++ b/includes/frame.h
@@ -236,6 +236,7 @@ typedef struct frame_s {
 
     #define PLAYER frame->game->player
     #define TILE_SIZE 64
+    #define MAX_RAY_LENGTH 400.0f
     #define MAP_WIDTH 8
     #define MAP_HEIGHT 8
 

--- a/src/raycast/ray_cast_floor_and_ceiling.c
+++ b/src/raycast/ray_cast_floor_and_ceiling.c
@@ -55,6 +55,8 @@ static ray_data_t calculate_ray_data(raycasting_data_t *data,
         distance_factor = (WINDOWY * TILE_SIZE / 2.0f) /
             (screen_center - strip.y);
     result.distance = distance_factor / cosf(data->ray_angles[strip.x]);
+    if (result.distance > MAX_RAY_LENGTH)
+        result.distance = MAX_RAY_LENGTH;
     return result;
 }
 
@@ -103,6 +105,8 @@ static void draw_strip(frame_t *frame, raycasting_data_t *data,
             is_floor, v2f(pos.x, pos.y))
     };
     ray_data_t ray = calculate_ray_data(data, strip);
+    if (ray.distance > MAX_RAY_LENGTH)
+        return;
     world_pos_t world_pos = calculate_world_position(data, ray);
     sfVector2i tex_coords = calculate_texture_coordinates(data, world_pos);
 
@@ -119,8 +123,8 @@ static void draw_floor(frame_t *frame,
         .player_angle = PLAYER->angle.x,
         .player_pos = PLAYER->pos,
         .vertical_offset = (int)(WINDOWY * tanf(PLAYER->angle.y) / 2),
-        .strip_height = 2,
-        .strip_width = 2,
+        .strip_height = 4,
+        .strip_width = 4,
         .ray_angles = ray_angles
     };
     int start_y = WINDOWY / 2 + floor_data.vertical_offset;
@@ -140,8 +144,8 @@ static void draw_ceiling(frame_t *frame,
         .player_angle = PLAYER->angle.x,
         .player_pos = PLAYER->pos,
         .vertical_offset = (int)(WINDOWY * tanf(PLAYER->angle.y) / 2),
-        .strip_height = 2,
-        .strip_width = 2,
+        .strip_height = 3,
+        .strip_width = 3,
         .ray_angles = ray_angles
     };
     int end_y = WINDOWY / 2 + ceiling_data.vertical_offset;

--- a/src/scenes/game.c
+++ b/src/scenes/game.c
@@ -22,7 +22,7 @@ static void draw_enemies(frame_t *frame)
 int game(frame_t *frame)
 {
     update_player(PLAYER, &(frame->clock[1]), frame);
-    draw_floor_and_ceiling(frame);
+    cast_floor_ceiling_rays(frame);
     cast_all_rays(frame);
     draw_items(frame);
     draw_enemies(frame);


### PR DESCRIPTION
This pull request introduces enhancements to the raycasting system by implementing a maximum ray length constraint, adjusting rendering parameters for floor and ceiling, and renaming a function for clarity. These changes aim to improve rendering performance and maintain visual consistency.

### Raycasting Enhancements:
* Added a `MAX_RAY_LENGTH` constant (`400.0f`) to constrain the maximum distance for raycasting in `includes/frame.h`.
* Updated `calculate_ray_data` in `src/raycast/ray_cast_floor_and_ceiling.c` to cap the ray distance at `MAX_RAY_LENGTH`.
* Modified `draw_strip` to skip rendering if the ray distance exceeds `MAX_RAY_LENGTH`.

### Rendering Adjustments:
* Increased `strip_height` and `strip_width` for floor rendering from `2` to `4` in `draw_floor`.
* Adjusted `strip_height` and `strip_width` for ceiling rendering from `2` to `3` in `draw_ceiling`.