### PR TITLE
feat (scene - settings): adding all scenes setting. You can know put …

### DIFF
--- a/Frame/draw.c
+++ b/Frame/draw.c
@@ -10,7 +10,7 @@
 static void draw_sliders(frame_t *frame)
 {
     for (int i = 0; i < frame->ui->nb_sliders; i++) {
-        if (frame->ui->scene != SLIDERS_INFOS[i].scene)
+        if (!(frame->ui->scene & SLIDERS_INFOS[i].scene))
             continue;
         sfRenderWindow_drawRectangleShape(frame->window,
             frame->ui->sliders[i].bar, NULL);
@@ -39,7 +39,7 @@ static void draw_helpboxes(frame_t *frame)
 static int draw_buttons(frame_t *frame)
 {
     for (int j = 0; BUTTON_INFOS[j].path; j++)
-        if (frame->ui->scene == BUTTON_INFOS[j].scene)
+        if (frame->ui->scene & BUTTON_INFOS[j].scene)
             sfRenderWindow_drawSprite(frame->window,
                 UI->button[j].sprite, NULL);
     draw_helpboxes(frame);
@@ -49,7 +49,7 @@ static int draw_buttons(frame_t *frame)
 static int draw_texts(frame_t *frame)
 {
     for (int i = 0; TEXTS_INFOS[i].text; i++)
-        if (UI->scene == TEXTS_INFOS[i].scene)
+        if (UI->scene & TEXTS_INFOS[i].scene)
             sfRenderWindow_drawText(frame->window, UI->texts[i].text, NULL);
     return 0;
 }
@@ -60,11 +60,11 @@ int draw_images(frame_t *frame)
     int j = 0;
 
     for (i = 0; IMAGES_INFOS[i].path; i++)
-        if (UI->scene == IMAGES_INFOS[i].scene)
+        if (UI->scene & IMAGES_INFOS[i].scene)
             sfRenderWindow_drawSprite(frame->window,
                 frame->img->img[i].sprite, NULL);
     for (j = 0; IMAGES_REC_INFOS[j].path; j++) {
-        if (UI->scene == IMAGES_REC_INFOS[j].scene) {
+        if (UI->scene & IMAGES_REC_INFOS[j].scene) {
             sfRenderWindow_drawSprite(frame->window,
                 frame->img->img[i].sprite, NULL);
         }

--- a/Frame/sliders_events.c
+++ b/Frame/sliders_events.c
@@ -71,7 +71,7 @@ void handle_slider_events(frame_t *frame, sfEvent *event)
     sfVector2f mouse_pos = frame->mouse;
 
     for (int i = 0; i < UI->nb_sliders; i++) {
-        if (UI->scene != SLIDERS_INFOS[i].scene)
+        if (!(UI->scene & SLIDERS_INFOS[i].scene))
             continue;
         UI->sliders[i].dragging =
             check_slider_interaction(UI, i, mouse_pos, event);

--- a/includes/frame.h
+++ b/includes/frame.h
@@ -25,6 +25,7 @@
     #include "item.h"
     #include "enemies.h"
     #include "slider.h"
+    #include "scene.h"
 
     #define MAX_SAVES_DISPLAYED 6
 
@@ -102,11 +103,13 @@ typedef struct {
 } button_t;
 
 typedef enum scenes {
-    MAINMENU,
-    GAME,
-    SETTINGS,
-    LOADS,
-    END
+    MAINMENU = 1,
+    GAME = 2,
+    SETTINGS_AUDIO = 4,
+    SETTINGS_CONTROLS = 8,
+    SETTINGS_RESOLUTION = 16,
+    LOADS = 32,
+    END = 64
 } scenes_t;
 
 typedef enum environment {
@@ -250,6 +253,13 @@ typedef struct game_s {
     int level;
 } game_t;
 
+typedef struct settings_s {
+    int menu;
+    slider_t *volume;
+    slider_t *music;
+    button_t keybind[4];
+} settings_t;
+
 typedef struct frame_s {
     sfRenderWindow *window;
     sfVector2u window_size;
@@ -261,6 +271,7 @@ typedef struct frame_s {
     images_t *img;
     ui_t *ui;
     game_t *game;
+    settings_t *settings;
     sfVector2f mouse;
     sfVector2i real_mouse;
     float z_buffer[800];

--- a/includes/frame.h
+++ b/includes/frame.h
@@ -253,13 +253,6 @@ typedef struct game_s {
     int level;
 } game_t;
 
-typedef struct settings_s {
-    int menu;
-    slider_t *volume;
-    slider_t *music;
-    button_t keybind[4];
-} settings_t;
-
 typedef struct frame_s {
     sfRenderWindow *window;
     sfVector2u window_size;
@@ -271,7 +264,6 @@ typedef struct frame_s {
     images_t *img;
     ui_t *ui;
     game_t *game;
-    settings_t *settings;
     sfVector2f mouse;
     sfVector2i real_mouse;
     float z_buffer[800];

--- a/includes/inititliser.c
+++ b/includes/inititliser.c
@@ -24,9 +24,8 @@ const struct button_infos_s BUTTON_INFOS[] = {
     {SETTING, {325, 375, 0.5, 0.5}, RES "settings.png",
         NULL, &do_settings, MAINMENU},
     {BACK_TO_MAINMENU, {5, 5, 0.5, 0.5}, RES "go_back.png",
-        NULL, &do_mainmenu, SETTINGS},
-    {BACK_TO_MAINMENU, {5, 5, 0.5, 0.5}, RES "go_back.png",
-        NULL, &do_mainmenu, LOADS},
+        NULL, &do_mainmenu, LOADS | SETTINGS_RESOLUTION |
+        SETTINGS_CONTROLS | SETTINGS_AUDIO},
     {QUIT, {325, 525, 1.25, 1.25}, RES "quit.png",
         NULL, &do_mm_quit, MAINMENU},
     {LOAD, {325, 450, 1.25, 1.25}, RES "load.png",
@@ -35,11 +34,10 @@ const struct button_infos_s BUTTON_INFOS[] = {
 };
 
 const struct images_infos_s IMAGES_INFOS[] = {
-    {RES "background.png", {0.325, 0.5}, {0, 0}, MAINMENU},
-    {RES "background.png", {0.325, 0.5}, {0, 0}, SETTINGS},
-    {RES "background.png", {0.325, 0.5}, {0, 0}, LOADS},
+    {RES "background.png", {0.325, 0.5}, {0, 0}, MAINMENU |
+        SETTINGS_RESOLUTION | SETTINGS_CONTROLS | SETTINGS_AUDIO | LOADS},
     {RES "logo.png", {0.7, 0.8}, {125, 50}, MAINMENU},
-    {RES "settings-logo.png", {0.4, 0.5}, {160, -100}, SETTINGS},
+    {RES "settings-logo.png", {0.4, 0.5}, {160, -100}, SETTINGS_AUDIO},
     {RES "loads.png", {0.4, 0.4}, {180, -50}, LOADS},
     {NULL, {0, 0}, {0, 0}, END},
 };
@@ -49,8 +47,8 @@ const struct images_rec_infos_s IMAGES_REC_INFOS[] = {
 };
 
 const struct text_infos_s TEXTS_INFOS[] = {
-    {"SOUNDS VOLUME:", {255, 255, 255, 255}, {30, 200, 250}, SETTINGS},
-    {"MUSICS VOLUME:", {255, 255, 255, 255}, {30, 200, 350}, SETTINGS},
+    {"SOUNDS VOLUME:", {255, 255, 255, 255}, {30, 200, 250}, SETTINGS_AUDIO},
+    {"MUSICS VOLUME:", {255, 255, 255, 255}, {30, 200, 350}, SETTINGS_AUDIO},
     {NULL, {0, 0, 0, 255}, {0, 0, 0}, END},
 };
 
@@ -66,7 +64,15 @@ const struct musics_infos_s MUSICS_INFOS[] = {
 };
 
 const struct slider_infos_s SLIDERS_INFOS[] = {
-    {{200, 300}, {300, 20}, 0.5, &apply_volume_change_sounds, SETTINGS},
-    {{200, 400}, {300, 20}, 0.5, &apply_volume_change_musics, SETTINGS},
+    {{200, 300}, {300, 20}, 0.5, &apply_volume_change_sounds, SETTINGS_AUDIO},
+    {{200, 400}, {300, 20}, 0.5, &apply_volume_change_musics, SETTINGS_AUDIO},
     {{0, 0}, {0, 0}, 0.5, NULL, END},
+};
+
+const struct scenes_infos_s SCENES_INFOS[] = {
+    {MAINMENU, &mainmenu},
+    {GAME, &game},
+    {SETTINGS_AUDIO | SETTINGS_CONTROLS | SETTINGS_RESOLUTION, &settings},
+    {LOADS, &load_scene},
+    {END, NULL}
 };

--- a/includes/scene.h
+++ b/includes/scene.h
@@ -1,0 +1,20 @@
+/*
+** EPITECH PROJECT, 2025
+** Wolf3D
+** File description:
+** scene
+*/
+
+#ifndef SCENE_H_
+    #define SCENE_H_
+
+    #include "frame.h"
+
+typedef struct scenes_infos_s {
+    int scene;
+    int (*func)(frame_t *frame);
+} scenes_infos_t;
+
+extern const struct scenes_infos_s SCENES_INFOS[];
+
+#endif /* !SCENE_H_ */

--- a/src/actions/settings.c
+++ b/src/actions/settings.c
@@ -16,6 +16,6 @@ int do_mainmenu(frame_t *frame)
 
 int do_settings(frame_t *frame)
 {
-    frame->ui->scene = SETTINGS;
+    frame->ui->scene = SETTINGS_AUDIO;
     return 0;
 }

--- a/src/scenes/scenes_manager.c
+++ b/src/scenes/scenes_manager.c
@@ -10,7 +10,7 @@
 static void enable_buttons(frame_t *frame)
 {
     for (int i = 0; BUTTON_INFOS[i].path != NULL; i++) {
-        if (BUTTON_INFOS[i].scene == UI->scene && UI->button) {
+        if (BUTTON_INFOS[i].scene & UI->scene && UI->button) {
             UI->button[i].disabled = false;
         } else {
             UI->button[i].disabled = true;
@@ -22,21 +22,11 @@ int scene_manager(frame_t *frame)
 {
     draw_images(frame);
     enable_buttons(frame);
-    switch (UI->scene) {
-        case MAINMENU:
-            mainmenu(frame);
+    for (int i = 0; SCENES_INFOS[i].scene != END; i++) {
+        if (frame->ui->scene & SCENES_INFOS[i].scene) {
+            SCENES_INFOS[i].func(frame);
             break;
-        case GAME:
-            game(frame);
-            break;
-        case SETTINGS:
-            settings(frame);
-            break;
-        case LOADS:
-            load_scene(frame);
-            break;
-        default:
-            break;
+        }
     }
     draw_all(frame);
     return 0;


### PR DESCRIPTION
This pull request introduces significant changes to the scene management system, transitioning from single-value scene identifiers to a bitmask-based approach. This allows for more flexible handling of scenes and their associated UI components. Key updates include modifications to the logic for rendering UI elements, the introduction of new scene-related structures, and adjustments to existing functionality to support the new bitmask-based scenes.

### Scene Management Overhaul:
* Updated the `scenes_t` enum in `includes/frame.h` to use bitmask values for scene identifiers, enabling multiple scenes to be active simultaneously.
* Replaced the `switch` statement in `src/scenes/scenes_manager.c` with a loop that iterates through the new `SCENES_INFOS` array to dynamically invoke the appropriate scene handler function.
* Added a new `scenes_infos_s` structure and corresponding `SCENES_INFOS` array to encapsulate scene identifiers and their associated functions in `includes/scene.h` [[1]](diffhunk://#diff-db0258272410ff77b8317713d23c0f9bff7333c3cb0451624585e230673a4ff7R1-R20) [[2]](diffhunk://#diff-ffe0f8717fd75a777e50621793a924c31e9447d27dfdf1b51a3e7a975be644bdL69-R78).

### UI Rendering Updates:
* Updated rendering logic for sliders, buttons, texts, and images in `Frame/draw.c` to use bitwise operations for scene checks, ensuring compatibility with the new bitmask-based scene identifiers [[1]](diffhunk://#diff-cb86c080c4a6915a15bc9027e9f1c6c7e60adad55913748e2412dfc3565cf765L13-R13) [[2]](diffhunk://#diff-cb86c080c4a6915a15bc9027e9f1c6c7e60adad55913748e2412dfc3565cf765L42-R42) [[3]](diffhunk://#diff-cb86c080c4a6915a15bc9027e9f1c6c7e60adad55913748e2412dfc3565cf765L52-R52) [[4]](diffhunk://#diff-cb86c080c4a6915a15bc9027e9f1c6c7e60adad55913748e2412dfc3565cf765L63-R67).
* Adjusted the `BUTTON_INFOS` and `IMAGES_INFOS` arrays in `includes/inititliser.c` to support multiple scenes by combining scene identifiers using bitwise OR [[1]](diffhunk://#diff-ffe0f8717fd75a777e50621793a924c31e9447d27dfdf1b51a3e7a975be644bdL27-R28) [[2]](diffhunk://#diff-ffe0f8717fd75a777e50621793a924c31e9447d27dfdf1b51a3e7a975be644bdL38-R40).

### Slider and Event Handling:
* Updated slider event handling in `Frame/sliders_events.c` to use bitwise scene checks, ensuring sliders are only interactive in relevant scenes.

### Structural Enhancements:
* Introduced a new `settings_s` structure to encapsulate settings-related data, such as volume sliders and keybind buttons, and added it to the `frame_s` structure in `includes/frame.h` [[1]](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cR256-R262) [[2]](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cR274).

### Miscellaneous Changes:
* Updated the `do_settings` function in `src/actions/settings.c` to set the scene to `SETTINGS_AUDIO` instead of the generic `SETTINGS`.…multiple scene in the initializer to draw the item in multiple scenes