### PR TITLE
feat (draw - objects): all objects are now draw by distance

### DIFF
--- a/includes/frame.h
+++ b/includes/frame.h
@@ -298,7 +298,8 @@ typedef struct draw_object_s {
     float distance;
     enum {
         ITEM_OBJ,
-        ENEMY_OBJ
+        ENEMY_OBJ,
+        FIXED_OBJ
     } type;
     union {
         struct {
@@ -307,6 +308,9 @@ typedef struct draw_object_s {
         struct {
             int index;
         } enemy;
+        struct {
+            int index;
+        } fixed_object;
     } data;
 } draw_object_t;
 


### PR DESCRIPTION
This pull request introduces support for rendering "fixed objects" in the game. The changes include updates to the `draw_object_t` structure, adjustments to object handling logic, and removal of redundant rendering functions.

### Updates to `draw_object_t` structure:
* Added a new `FIXED_OBJ` type to the `type` enumeration in `draw_object_t`.
* Introduced a `fixed_object` union member to store the index of fixed objects.

### Object handling logic:
* Updated the total object count in `init_objects_array` to include `NB_FIXED_OBJECTS`.
* Added a new function, `add_fixed_objects_to_objects`, to calculate distances for fixed objects and append them to the `objects` array.
* Modified `calculate_distances` to include fixed objects in the distance calculations.
* Updated `draw_objects_by_distance` to render fixed objects using the new `FIXED_OBJ` type.

### Code cleanup:
* Removed the now redundant `draw_all_fixed_objects` function call from the main game loop.