### PR TITLE
feat (ennemies - drop): you can now in parameters give an item name a…

### DIFF
--- a/Create/item.c
+++ b/Create/item.c
@@ -7,6 +7,18 @@
 
 #include "frame.h"
 
+static int find_id(frame_t *frame)
+{
+    int id = 0;
+
+    for (int i = 0; i < NBITEMS; i++) {
+        if (ITEM[i].id != id)
+            break;
+        id++;
+    }
+    return (id);
+}
+
 int create_item(frame_t *frame, char *str, sfVector2f scale, sfVector3f pos)
 {
     if (NBITEMS == 0)
@@ -20,7 +32,7 @@ int create_item(frame_t *frame, char *str, sfVector2f scale, sfVector3f pos)
         return 84;
     ITEM[NBITEMS].scale = scale;
     ITEM[NBITEMS].pos = pos;
-    ITEM[NBITEMS].id = NBITEMS;
+    ITEM[NBITEMS].id = find_id(frame);
     NBITEMS++;
     return 0;
 }

--- a/includes/enemies.h
+++ b/includes/enemies.h
@@ -20,6 +20,7 @@ struct enemy_infos_s {
     float attack_range;
     float damages;
     float attack_cooldown;
+    char *drop_item;
 };
 
 extern const struct enemy_infos_s ENEMY_INFOS[];

--- a/includes/frame.h
+++ b/includes/frame.h
@@ -333,6 +333,7 @@ typedef struct enemy_s {
     sfVector2f scale;
     sfVector2f direction;
     sfIntRect rec;
+    char *drop;
     float angle;
     float speed;
     float damages;
@@ -646,6 +647,8 @@ void use_item(frame_t *frame, int item_index);
 void drop_item(frame_t *frame, int item_index);
 void draw_inventory_background(frame_t *frame);
 bool use_item_key(frame_t *frame);
+int get_item_index(char *name);
+void drop_item_at_pos(frame_t *frame, int item_index, sfVector2f pos);
 
 void draw_hud(frame_t *frame);
 

--- a/includes/inititliser.c
+++ b/includes/inititliser.c
@@ -7,32 +7,36 @@
 
 #include "frame.h"
 
+// PATH ; POS ; ANGLE; SCALE ; TYPE ; REC
 const struct fixed_object_infos_s FIXED_OBJECT_INFOS[] = {
     {RES "door.png", {128 + 32, 96, 0}, M_PI / 2,
         {64, 64}, DOOR_CLOSED, {0, 0, 128, 128}},
     {NULL, {0, 0, 0.1}, 0, {0, 0}, 0, {0, 0, 0, 0}}
 };
 
+// PATH ; SCALE ; POSITION ; REC ; NAME: ; IS_PICKABLE ; IS_USEABLE ; DESCRIPTION
 const struct item_infos_s ITEM_INFOS[] = {
     {RES "lamp.png", {0.7, 0.7}, {250, 250, 0.1},
         {-1, -1, -1, -1}, "lamp", false, false, NULL},
     {RES "barrel.png", {0.6, 0.6}, {150, 230, -0.50},
         {-1, -1, -1, -1}, "barrel", false, false, NULL},
     {RES "key.png", {0.5, 0.5}, {110, 96, -0.50},
-        {-1, -1, -1, -1}, "key", true, false, "The Key Of The Door"},
+        {-1, -1, -1, -1}, "Key", true, false, "The Key Of The Door"},
     {RES "key.png", {0.5, 0.5}, {250, 280, -0.50},
-        {-1, -1, -1, -1}, "key", true, false, "The Door of the Key"},
+        {-1, -1, -1, -1}, "Key", true, false, "The Key Of The Door"},
     {RES "heal.png", {0.4, 0.4}, {450, 300, -0.50},
         {-1, -1, -1, -1}, "Heal", true, true, "Heal of 20 HP"},
     {NULL, {0, 0}, {0, 0, 0}, {0, 0, 0, 0}, NULL, false, false, NULL},
 };
 
+// PATH ; SCALE ; POSITION ; REC ; SPEED ; LIFE ; DAMAGE ; ATTACK_RANGE ; COOLDOWN ; DROP (name of item or NULL if no drops)
 const struct enemy_infos_s ENEMY_INFOS[] = {
     {RES "enemy.png", {2.5, 2.5}, {250, 250, -0.90},
-        {0, 0, 65, 65}, 0.5, 100, 75, 10, 1},
-    {NULL, {0, 0}, {0, 0, 0}, {-1, -1, -1, -1}, 0, 0, 0, 0, 0}
+        {0, 0, 65, 65}, 0.5, 100, 75, 10, 1, "key"},
+    {NULL, {0, 0}, {0, 0, 0}, {-1, -1, -1, -1}, 0, 0, 0, 0, 0, NULL}
 };
 
+// TYPE ; SCALE & POSITION ; REC ; PATH ; HELPBOX_TEXT ; ACTION ; SCENE | SCENES
 const struct button_infos_s BUTTON_INFOS[] = {
     {PLAY, {325, 300, 0.5, 0.5}, RES "play.png",
         NULL, &do_play, MAINMENU},

--- a/src/enemy/update_ennemies.c
+++ b/src/enemy/update_ennemies.c
@@ -22,16 +22,19 @@ static void animate_die(enemy_t *enemy)
     enemy->rec.left = enemy->rec.width * current_frame;
 }
 
-static void handle_die(enemy_t *enemy)
+static void handle_die(frame_t *frame, enemy_t *enemy)
 {
+    int item_index = 0;
+
     if (enemy->life <= 0 && enemy->is_dead == false) {
         sfClock_restart(enemy->clock);
+        item_index = get_item_index(enemy->drop);
+        if (item_index > 0)
+            drop_item_at_pos(frame, item_index,
+                v2f(enemy->pos.x, enemy->pos.y));
         enemy->is_dead = true;
         enemy->is_moving = false;
         enemy->is_attacking = false;
-    }
-    if (sfKeyboard_isKeyPressed(sfKeyK)) {
-        enemy->life--;
     }
 }
 
@@ -84,7 +87,7 @@ void update_enemies(frame_t *frame)
             animate_die(&ENEMY[i]);
             continue;
         }
-        handle_die(&ENEMY[i]);
+        handle_die(frame, &ENEMY[i]);
         handle_attack(frame, &ENEMY[i]);
         if (ENEMY[i].follow_player)
             follow_player(frame, &ENEMY[i]);

--- a/src/init/init_game.c
+++ b/src/init/init_game.c
@@ -93,6 +93,7 @@ static bool init_enemies(frame_t *frame)
         ENEMY[NBENEMIES - 1].attack_range = ENEMY_INFOS[i].attack_range;
         ENEMY[NBENEMIES - 1].damages = ENEMY_INFOS[i].damages;
         ENEMY[NBENEMIES - 1].attack_cooldown = ENEMY_INFOS[i].attack_cooldown;
+        ENEMY[NBENEMIES - 1].drop = ENEMY_INFOS[i].drop_item;
     }
     if (result != 0)
         return false;

--- a/src/inventory/inventory_actions.c
+++ b/src/inventory/inventory_actions.c
@@ -60,6 +60,30 @@ void use_item(frame_t *frame, int item_index)
     }
 }
 
+void drop_item_at_pos(frame_t *frame, int item_index, sfVector2f pos)
+{
+    if (create_item(frame, ITEM_INFOS[item_index].path,
+        ITEM_INFOS[item_index].scale,
+        v3f(pos.x, pos.y, ITEM_INFOS[item_index].pos.z)) == 84)
+        return;
+    ITEM[NBITEMS - 1].rec = ITEM_INFOS[item_index].rec;
+    ITEM[NBITEMS - 1].name = ITEM_INFOS[item_index].name;
+    ITEM[NBITEMS - 1].pickable = ITEM_INFOS[item_index].pickable;
+    ITEM[NBITEMS - 1].useable = ITEM_INFOS[item_index].useable;
+    ITEM[NBITEMS - 1].description = ITEM_INFOS[item_index].description;
+}
+
+int get_item_index(char *name)
+{
+    if (name == NULL)
+        return -1;
+    for (int i = 0; ITEM_INFOS[i].path; i++) {
+        if (strcmp(ITEM_INFOS[i].name, name) == 0)
+            return i;
+    }
+    return -1;
+}
+
 bool use_item_key(frame_t *frame)
 {
     int index = -1;

--- a/src/raycast/fixed_object.c
+++ b/src/raycast/fixed_object.c
@@ -121,7 +121,7 @@ static void render_segment(frame_t *frame, render_context_t *ctx,
 
     if (segment->corrected_dist < 0.1f)
         return;
-    if (segment->screen_y < 0 || segment->screen_y > WINDOWY)
+    if (segment->screen_x < 0 || segment->screen_y > WINDOWX)
         return;
     if (frame->z_buffer[segment->screen_x] < segment->corrected_dist)
         return;

--- a/src/weapon/update_weapon.c
+++ b/src/weapon/update_weapon.c
@@ -19,11 +19,6 @@ float normalize_weapon_angle(float angle)
 void damage_enemy(frame_t *frame, enemy_t *enemy, int damage)
 {
     enemy->life -= damage;
-    if (enemy->life <= 0) {
-        enemy->life = 0;
-        enemy->is_dead = true;
-        ENEMIESALIVE--;
-    }
 }
 
 static void update_weapon_cooldown(weapon_t *weapon, float delta_time)


### PR DESCRIPTION
This pull request introduces several changes to enhance item handling, improve enemy interactions, and fix a rendering bug. The most significant updates include adding functionality to drop items when enemies die, implementing a unique ID system for items, and fixing a screen coordinate check in the rendering logic.

### Item Handling Enhancements:
* Added two new functions, `get_item_index` and `drop_item_at_pos`, to enable item retrieval by name and dropping items at specific positions. (`includes/frame.h`, `src/inventory/inventory_actions.c`) [[1]](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cR650-R651) [[2]](diffhunk://#diff-7b4887f5c36d19089a8f91ca6a87efb9c33fa54e55bc591fd68584fdc8bc7d75R63-R86)
* Updated the `create_item` function to assign unique IDs to items using the new `find_id` helper function. (`Create/item.c`) [[1]](diffhunk://#diff-d818e91c80937d45dcc1f547b099ed282c9d44f721766895b6b99a20ed7bfd69R10-R21) [[2]](diffhunk://#diff-d818e91c80937d45dcc1f547b099ed282c9d44f721766895b6b99a20ed7bfd69L23-R35)

### Enemy Interaction Improvements:
* Introduced a `drop_item` field to `enemy_infos_s` and `enemy_s` structures to specify items dropped by enemies upon death. (`includes/enemies.h`, `includes/frame.h`) [[1]](diffhunk://#diff-f3fb2a02af1d7b4d08fe78d761c9d907f1bf8ca21d6f0f19f1b814da0fa392d9R23) [[2]](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cR336)
* Modified the `handle_die` function to drop items at the enemy's position when they die. (`src/enemy/update_ennemies.c`) [[1]](diffhunk://#diff-620117508209eb57292313060684c27704af8d2db9f1c00d03625182ca122097L25-L35) [[2]](diffhunk://#diff-620117508209eb57292313060684c27704af8d2db9f1c00d03625182ca122097L87-R90)
* Updated enemy initialization to populate the `drop` field from `ENEMY_INFOS`. (`src/init/init_game.c`)

### Rendering Fix:
* Fixed a bug in `render_segment` where the screen coordinate check incorrectly used `screen_y` instead of `screen_x` for the horizontal boundary. (`src/raycast/fixed_object.c`)

### Miscellaneous:
* Adjusted the name of the "key" item in `ITEM_INFOS` for consistency. (`includes/inititliser.c`)
* Removed redundant logic for marking enemies as dead in `damage_enemy`. (`src/weapon/update_weapon.c`)…nd dead ennemy will drop it