### PR TITLE
Sprint

### DIFF
--- a/includes/frame.h
+++ b/includes/frame.h
@@ -497,7 +497,7 @@ typedef struct frame_s {
 
     #define PLAYER frame->game->player
     #define TILE_SIZE 64
-    #define MAX_RAY_LENGTH 400.0f
+    #define MAX_RAY_LENGTH 1500.0f
     #define MAP_WIDTH 16
     #define MAP_HEIGHT 16
 
@@ -561,6 +561,8 @@ extern const int map[MAP_HEIGHT][MAP_WIDTH];
     #define L_VW_Y (map_p_y + dir_y * radius - dir_x * radius * 0.5f)
     #define R_VW_X (map_p_x + dir_x * radius - dir_y * radius * 0.5f)
     #define R_VW_Y (map_p_y + dir_y * radius + dir_x * radius * 0.5f)
+
+    #define SPRINT_MOD 1.8f
 
 
 //CREATION

--- a/src/player/move.c
+++ b/src/player/move.c
@@ -44,15 +44,18 @@ static sfVector2f set_walk_pos(frame_t *frame, sfVector2i move,
     sfVector2f res = {0, 0};
     int input_nb = ((bool)move.x + (bool)move.y);
     float angle = player->angle.x;
+    float speed = player->speed;
     sfVector2f pos = player->pos;
     sfVector2i collision = {0, 0};
 
     if (!input_nb)
         return res;
+    if (sfKeyboard_isKeyPressed(sfKeyLShift))
+        speed *= SPRINT_MOD;
     res.x = (cos(angle) * move.x + sin(angle) * move.y);
-    res.x *= player->speed * player->delta_time;
+    res.x *= speed * player->delta_time;
     res.y = (sin(angle) * move.x + cos(angle) * -1 * move.y);
-    res.y *= player->speed * player->delta_time;
+    res.y *= speed * player->delta_time;
     collision = check_collisions(frame, v2f(pos.x + res.x, pos.y + res.y),
         player->pos, player->size);
     res.x *= !collision.x;

--- a/src/raycast/raycasting.c
+++ b/src/raycast/raycasting.c
@@ -57,7 +57,7 @@ float cast_single_ray(float ray_angle, frame_t *frame)
     float corrected_dist = 0;
     int obstacle = 0;
 
-    while (ray_length < 1000) {
+    while (ray_length < MAX_RAY_LENGTH) {
         ray_pos.x += ray_dir.x * ray_step;
         ray_pos.y += ray_dir.y * ray_step;
         obstacle = is_osbtacle(frame, ray_pos.x, ray_pos.y);


### PR DESCRIPTION
This pull request introduces enhancements to the game's movement and raycasting mechanics. The key changes include increasing the maximum raycasting distance, adding a sprint mechanic for the player, and updating relevant calculations to accommodate these features.

### Movement Enhancements:
* Introduced a sprint mechanic by defining a `SPRINT_MOD` multiplier and modifying the player's speed when the sprint key (`sfKeyLShift`) is pressed. (`includes/frame.h`: [[1]](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cR565-R566) `src/player/move.c`: [[2]](diffhunk://#diff-74a4e68f0a24e6b1c457fd8d56695c0d4cf8d937b1694ad0411b5c7b286284ceR47-R58)

### Raycasting Improvements:
* Increased the maximum raycasting distance by updating `MAX_RAY_LENGTH` from `400.0f` to `1500.0f`. (`includes/frame.h`: [includes/frame.hL500-R500](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cL500-R500))
* Updated the raycasting loop to use the new `MAX_RAY_LENGTH` constant for determining the maximum ray length. (`src/raycast/raycasting.c`: [src/raycast/raycasting.cL60-R60](diffhunk://#diff-2aff993ae311e58229014f5df8c02a34782e1e711b833f87b23a6e598bebc7f7L60-R60))