### PR TITLE
feat (gameplay - lose and win): you can know use and win with a beautiful score in function of the difficulty, items get and nb ennemies alive (also time)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ SRC	=	includes/inititliser.c          \
         $(SCENES_DIR)settings.c                    \
         $(SCENES_DIR)scenes_manager.c           \
         $(SCENES_DIR)loads_scene.c                    \
+        $(SCENES_DIR)victory.c                \
+        $(SCENES_DIR)gameover.c                    \
         $(CREATE_DIR)button.c                   \
         $(CREATE_DIR)clocks.c                   \
         $(CREATE_DIR)sound.c                    \
@@ -92,6 +94,7 @@ SRC	=	includes/inititliser.c          \
         $(GAME_DIR)load_items_data.c       \
         $(GAME_DIR)load_enemies_data.c       \
         $(GAME_DIR)timer.c       \
+        $(GAME_DIR)game_status.c       \
         $(INVENTORY_DIR)init_inventory.c       \
         $(INVENTORY_DIR)inventory.c       \
         $(INVENTORY_DIR)draw_inventory.c       \

--- a/includes/button.h
+++ b/includes/button.h
@@ -42,6 +42,7 @@ enum buttons_actions {
     SAVE,
     RESUME,
     QUIT_GAME,
+    BGAME_OVER,
     AITEM,
     SAVES_LIST,
 };

--- a/includes/frame.h
+++ b/includes/frame.h
@@ -121,7 +121,9 @@ typedef enum scenes {
     SETTINGS_RESOLUTION = 16,
     LOADS = 32,
     PAUSE = 64,
-    END = 128
+    WIN = 128,
+    GAME_OVER = 256,
+    END = 512,
 } scenes_t;
 
 typedef enum environment {
@@ -644,12 +646,15 @@ void enable_button(frame_t *frame, int *button_indexes, int nb_buttons);
 sfVector2f get_mouseposition(sfRenderWindow *window);
 
 int scene_manager(frame_t *frame);
-void change_scene(frame_t *frame, int scene);
+bool change_scene(frame_t *frame, int scene);
+
 //SCENES
 int mainmenu(frame_t *frame);
 int game(frame_t *frame);
 int settings(frame_t *frame);
 int load_scene(frame_t *frame);
+int victory(frame_t *frame);
+int game_over(frame_t *frame);
 
 //RAYCAST
 int is_osbtacle(frame_t *frame, int x, int y);
@@ -734,6 +739,8 @@ bool load_frame(frame_t *frame, char *save);
 int loads_saved_games(frame_t *frame);
 void free_save(saves_t *saves, frame_t *frame);
 void update_timer(frame_t *frame);
+int check_game_status(frame_t *frame);
+int get_storable_item_count(frame_t *frame);
 
 //KEYBINDS
 sfKeyCode *get_button_keycode(frame_t *frame, int action);

--- a/includes/inititliser.c
+++ b/includes/inititliser.c
@@ -37,12 +37,12 @@ const struct item_infos_s ITEM_INFOS[] = {
 // ATTACK_RANGE; FOLLOW_RANGE ; DAMAGE ; COOLDOWN ; DROP
 // (name of item or NULL if no drops)
 const struct enemy_infos_s ENEMY_INFOS[] = {
-    {RES "enemy.png", {2.5, 2.5}, {250, 250, -0.90},
+    /*{RES "enemy.png", {2.5, 2.5}, {250, 250, -0.90},
         {0, 0, 65, 65}, 0.5, 100, 150, 200, 10, 1, "Ammo_box", BASIC},
     {RES "enemy2.png", {2.5, 2.5}, {250, 300, -0.90},
-        {0, 0, 65, 65}, 0.5, 100, 150, 200, 10, 1, "Heal", BASIC},
-    /*{RES "Hitler1.png", {2.5, 2.5}, {250, 350, -0.90},
-        {0, 0, 74, 72}, 0.5, 400, 100, 300, 20, 0.5f, NULL, HITLER},*/
+        {0, 0, 65, 65}, 0.5, 100, 150, 200, 10, 1, "Heal", BASIC},*/
+    {RES "Hitler1.png", {2.5, 2.5}, {250, 350, -0.90},
+        {0, 0, 74, 72}, 0.5, 400, 100, 300, 20, 0.5f, NULL, HITLER},
     {NULL, {0, 0}, {0, 0, 0}, {-1, -1, -1, -1}, 0, 0, 0, 0, 0, 0, NULL, 0}
 };
 
@@ -93,6 +93,10 @@ const struct button_infos_s BUTTON_INFOS[] = {
         NULL, NULL, SETTINGS_CONTROLS},
     {KEY_PAUSE, {575, 450, 0.5, 0.5}, RES "keybind.png",
         NULL, NULL, SETTINGS_CONTROLS},
+    {QUIT, {325, 400, 1.5, 1.5}, RES "quit.png",
+        NULL, &do_mm_quit, WIN},
+    {QUIT, {325, 400, 1.5, 1.5}, RES "quit.png",
+        NULL, &do_mm_quit, GAME_OVER},
     {0, {0, 0, 0, 0}, NULL, NULL, NULL, END}
 };
 
@@ -105,6 +109,8 @@ const struct images_infos_s IMAGES_INFOS[] = {
     {RES "loads.png", {0.4, 0.4}, {180, -50}, LOADS},
     {RES "panel.png", {0.4, 0.5}, {200, 60}, PAUSE},
     {RES "pause.png", {0.3, 0.3}, {250, -50}, PAUSE},
+    {RES "victory.png", {3, 3}, {180, 0}, WIN},
+    {RES "gameover.png", {3, 3}, {180, 0}, GAME_OVER},
     {NULL, {0, 0}, {0, 0}, END},
 };
 
@@ -124,6 +130,8 @@ const struct text_infos_s TEXTS_INFOS[] = {
     {"Inventory: ", {255, 255, 255, 255}, {30, 440, 380}, SETTINGS_CONTROLS},
     {"Pause: ", {255, 255, 255, 255}, {30, 440, 455}, SETTINGS_CONTROLS},
     {"00:00", {255, 255, 255, 255}, {40, 10, 10}, GAME},
+    {"Score :", {255, 255, 255, 255}, {40, 220, 300}, WIN | GAME_OVER},
+    {"Difficulty: ", {255, 255, 255, 255}, {40, 220, 230}, SETTINGS_CONTROLS},
     {NULL, {0, 0, 0, 255}, {0, 0, 0}, END},
 };
 
@@ -141,7 +149,7 @@ const struct musics_infos_s MUSICS_INFOS[] = {
 const struct slider_infos_s SLIDERS_INFOS[] = {
     {{200, 300}, {300, 20}, 0.5, &apply_volume_change_sounds, SETTINGS_AUDIO},
     {{200, 400}, {300, 20}, 0.5, &apply_volume_change_musics, SETTINGS_AUDIO},
-    {{400, 250}, {300, 20}, 1.0, &apply_difficulty_change, SETTINGS_CONTROLS},
+    {{400, 250}, {300, 20}, 0.0, &apply_difficulty_change, SETTINGS_CONTROLS},
     {{0, 0}, {0, 0}, 0.5, NULL, END},
 };
 
@@ -149,6 +157,8 @@ const struct scenes_infos_s SCENES_INFOS[] = {
     {MAINMENU, &mainmenu},
     {GAME, &game},
     {LOADS, &load_scene},
+    {WIN, &victory},
+    {GAME_OVER, &game_over},
     {END, NULL}
 };
 

--- a/includes/keyname.h
+++ b/includes/keyname.h
@@ -50,8 +50,8 @@ static const key_name_t KEY_NAMES[] = {
     {sfKeyF5, "F5"}, {sfKeyF6, "F6"}, {sfKeyF7, "F7"}, {sfKeyF8, "F8"},
     {sfKeyF9, "F9"}, {sfKeyF10, "F10"}, {sfKeyF11, "F11"}, {sfKeyF12, "F12"},
     {sfKeyF13, "F13"}, {sfKeyF14, "F14"}, {sfKeyF15, "F15"},
-    {sfKeyPause, "Pause"},
-    {sfKeyUnknown, "Unknown"}
+    {sfKeyPause, "Pause"}, {sfKeyUnknown, "Unknown"},
+    {0, NULL}
 };
 
 #endif /* !KEYNAME_H_ */

--- a/main.c
+++ b/main.c
@@ -19,6 +19,7 @@ int main(int argc, char **argv)
         free(frame);
         return 84;
     }
+    sfRenderWindow_requestFocus(WINDOW);
     while (sfRenderWindow_isOpen(WINDOW)) {
         handle_event(&(frame->event), frame);
         sfRenderWindow_clear(WINDOW, sfBlack);

--- a/src/actions/change_scene.c
+++ b/src/actions/change_scene.c
@@ -7,15 +7,16 @@
 
 #include "frame.h"
 
-void change_scene(frame_t *frame, int scene)
+bool change_scene(frame_t *frame, int scene)
 {
     if (scene == frame->ui->scene)
-        return;
+        return true;
     if (scene & (SETTINGS_CONTROLS | SETTINGS_RESOLUTION) ||
         UI->scene & (SETTINGS_CONTROLS | SETTINGS_RESOLUTION)) {
         UI->scene = scene;
-        return;
+        return true;
     }
     UI->last_scene = UI->scene;
     UI->scene = scene;
+    return false;
 }

--- a/src/actions/save.c
+++ b/src/actions/save.c
@@ -96,9 +96,31 @@ static bool save_new_game(frame_t *frame)
     return true;
 }
 
+static void delete_save(char *save, char *name)
+{
+    char image_path[256];
+
+    if (!save)
+        save = "sswolfs/save-EthanLeGrand.ww2";
+    if (!name)
+        name = "EthanLeGrand";
+    snprintf(image_path, sizeof(image_path),
+        "sswolfs/save-%s.png", name);
+    if (remove(save) != 0)
+        fprintf(stderr, "Error deleting save file: %s\n", save);
+    if (remove(image_path) != 0)
+        fprintf(stderr, "Error deleting save image: %s\n", image_path);
+}
+
 int do_save(frame_t *frame)
 {
     create_save_directory();
+    if (frame->victory) {
+        delete_save(frame->save, frame->name);
+        return 0;
+    }
+    if (frame->game_over)
+        return 0;
     if (frame->save)
         return save_game(frame->save, frame);
     else

--- a/src/actions/sliders.c
+++ b/src/actions/sliders.c
@@ -27,12 +27,13 @@ int apply_volume_change_musics(frame_t *frame, float volume)
 
 int apply_difficulty_change(frame_t *frame, float difficulty)
 {
-    frame->game->difficulty = 3 * difficulty;
+    if (frame->ui->scene == GAME || frame->played)
+        return 0;
+    frame->game->difficulty = 3 * (1 - difficulty);
     if (frame->game->difficulty < 1)
         frame->game->difficulty = 1;
     else if (frame->game->difficulty > 3)
         frame->game->difficulty = 3;
-    if (!(frame->ui->scene & GAME))
-        frame->game->timer = 600 * 100 * frame->game->difficulty / 3;
+    frame->game->timer = 600 * frame->game->difficulty / 3;
     return 0;
 }

--- a/src/game/game_status.c
+++ b/src/game/game_status.c
@@ -1,0 +1,18 @@
+/*
+** EPITECH PROJECT, 2025
+** Wolf3D
+** File description:
+** game_status
+*/
+
+#include "frame.h"
+
+int check_game_status(frame_t *frame)
+{
+    if (PLAYER->life <= 0 || frame->game_over) {
+        frame->game_over = true;
+        change_scene(frame, GAME_OVER);
+        return 1;
+    }
+    return 0;
+}

--- a/src/raycast/item.c
+++ b/src/raycast/item.c
@@ -88,9 +88,10 @@ void draw_item(frame_t *frame, item_t *item)
         return;
     render_item_columns(frame, item->texture, &data, item->scale);
     if (item->pickable && data.distance < 100.0f) {
-        name = malloc(strlen(item->name) + 5);
+        name = malloc(strlen(item->name) +
+            strlen(get_key_name(KEYBIND->interact)) + 1);
         if (name != NULL) {
-            snprintf(name, strlen(item->name) + 5, "[%s] %s",
+            snprintf(name, strlen(item->name) + 6, "[%s] %s",
                 get_key_name(KEYBIND->interact), item->name);
             draw_3d_text(frame, v3f(item->pos.x, item->pos.y,
                 item->pos.z + 0.25f), name, v2f(0.4f, 0.4f));

--- a/src/scenes/game.c
+++ b/src/scenes/game.c
@@ -141,6 +141,7 @@ int game(frame_t *frame)
 {
     float delta_time = get_delta_time(&(frame->clock[2]));
 
+    check_game_status(frame);
     sfRenderWindow_clear(WINDOW, sfBlack);
     clear_light_map(frame);
     applied(frame->img);

--- a/src/scenes/gameover.c
+++ b/src/scenes/gameover.c
@@ -1,0 +1,38 @@
+/*
+** EPITECH PROJECT, 2025
+** Wolf3D
+** File description:
+** gameover
+*/
+
+#include "frame.h"
+
+static void display_score(frame_t *frame, int score, sfText *text)
+{
+    char score_text[50];
+
+    snprintf(score_text, sizeof(score_text), "Your score : %d", score);
+    sfText_setString(text, score_text);
+    sfRenderWindow_drawText(frame->window, text, NULL);
+}
+
+static int update_score(frame_t *frame)
+{
+    int score = 10000 / (frame->game->difficulty);
+
+    score -= frame->game->nb_enemies_alive * 100;
+    score -= frame->game->timer / 100;
+    score += frame->game->player->life;
+    score -= get_storable_item_count(frame) * 100;
+    return score / 2;
+}
+
+int game_over(frame_t *frame)
+{
+    int score = update_score(frame);
+
+    PLAYER->pause = true;
+    sfRenderWindow_setMouseCursorVisible(frame->window, sfTrue);
+    display_score(frame, score, frame->ui->texts[11].text);
+    return 0;
+}

--- a/src/scenes/settings.c
+++ b/src/scenes/settings.c
@@ -9,7 +9,7 @@
 
 const char *get_key_name(sfKeyCode key_code)
 {
-    for (size_t i = 0; i < sizeof(KEY_NAMES) / sizeof(KEY_NAMES[0]); i++) {
+    for (size_t i = 0; KEY_NAMES[i].name; i++) {
         if (KEY_NAMES[i].code == key_code) {
             return KEY_NAMES[i].name;
         }

--- a/src/scenes/victory.c
+++ b/src/scenes/victory.c
@@ -1,0 +1,50 @@
+/*
+** EPITECH PROJECT, 2025
+** Wolf3D
+** File description:
+** victory
+*/
+
+#include "frame.h"
+
+static void display_score(frame_t *frame, int score, sfText *text)
+{
+    char score_text[50];
+
+    snprintf(score_text, sizeof(score_text), "Your score: %d", score);
+    sfText_setString(text, score_text);
+    sfRenderWindow_drawText(frame->window, text, NULL);
+}
+
+int get_storable_item_count(frame_t *frame)
+{
+    int count = 0;
+
+    for (int i = 0; i < NBITEMS; i++) {
+        if (ITEM[i].pickable || ITEM[i].useable) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static int update_score(frame_t *frame)
+{
+    int score = 10000 / (frame->game->difficulty);
+
+    score -= frame->game->nb_enemies_alive * 100;
+    score -= frame->game->timer / 100;
+    score += frame->game->player->life;
+    score -= get_storable_item_count(frame) * 100;
+    return score;
+}
+
+int victory(frame_t *frame)
+{
+    int score = update_score(frame);
+
+    PLAYER->pause = true;
+    sfRenderWindow_setMouseCursorVisible(frame->window, sfTrue);
+    display_score(frame, score, frame->ui->texts[11].text);
+    return 0;
+}

--- a/src/vfx/combat_vfx.c
+++ b/src/vfx/combat_vfx.c
@@ -187,8 +187,10 @@ bool end_explosions(frame_t *frame)
     const float rand = 30.0f;
     sfVector3f pos = get_hitler_pos(frame);
 
-    if (!frame->victory || explosions == 0)
+    if (!frame->victory)
         return false;
+    if (explosions == 0)
+        return change_scene(frame, WIN);
     elapsed += PLAYER->delta_time * 1000.0f;
     if (elapsed >= interval) {
         pos.x = rand_range(pos.x - rand, pos.x + rand);


### PR DESCRIPTION
This pull request introduces significant changes to the game framework, primarily adding new "Victory" and "Game Over" scenes, alongside various supporting updates to manage game state, scoring, and difficulty adjustments. The changes include updates to the scene management system, new assets and logic for the additional scenes, and improvements to existing functionality.

### New Scenes and Scene Management:

* Added "Victory" and "Game Over" scenes to the `scenes_t` enum and implemented corresponding functions (`victory` and `game_over`) to handle their logic. These scenes display the player's score and other relevant information. (`[[1]](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cL124-R126)`, `[[2]](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cL647-R657)`, `[[3]](diffhunk://#diff-d1ea7d9823ead59252801de2909de788dcd6ab65b22f40c13240719811315669R1-R50)`, `[[4]](diffhunk://#diff-a087c5bcedf3cc64427b5a25d393dcd7f6daf6ef0055e649b518b2d3b16479f5R1-R38)`)
* Updated `change_scene` to return a `bool` indicating whether the scene was successfully changed, improving scene transition handling. (`[src/actions/change_scene.cL10-R21](diffhunk://#diff-66c0134d3e748d26536fdb901f604e5b94d47fd5f9d6fcfb2c7dc66330a30e75L10-R21)`)

### Game State and Scoring:

* Introduced a `check_game_status` function to determine if the game is over based on player health or other conditions. This is now called in the game loop to trigger the "Game Over" scene when necessary. (`[[1]](diffhunk://#diff-a1431638c5954dbf162ee755adabbefb01d8d6edc87e971d5e9b6681592430cdR1-R18)`, `[[2]](diffhunk://#diff-01468cafe50f441d297ec3ec6554da9eb914fb9bf45d8c310a96cd553127f8ccR144)`)
* Added score calculation logic to both the "Victory" and "Game Over" scenes, factoring in difficulty, remaining enemies, and other gameplay metrics. (`[[1]](diffhunk://#diff-a087c5bcedf3cc64427b5a25d393dcd7f6daf6ef0055e649b518b2d3b16479f5R1-R38)`, `[[2]](diffhunk://#diff-d1ea7d9823ead59252801de2909de788dcd6ab65b22f40c13240719811315669R1-R50)`)

### Assets and UI Updates:

* Added new assets for the "Victory" and "Game Over" scenes, including images and text elements, and updated the `SCENES_INFOS`, `IMAGES_INFOS`, and `TEXTS_INFOS` arrays to include these assets. (`[[1]](diffhunk://#diff-ffe0f8717fd75a777e50621793a924c31e9447d27dfdf1b51a3e7a975be644bdR112-R113)`, `[[2]](diffhunk://#diff-ffe0f8717fd75a777e50621793a924c31e9447d27dfdf1b51a3e7a975be644bdR133-R134)`, `[[3]](diffhunk://#diff-ffe0f8717fd75a777e50621793a924c31e9447d27dfdf1b51a3e7a975be644bdL144-R161)`)

### Difficulty and Gameplay Adjustments:

* Modified the `apply_difficulty_change` function to prevent difficulty adjustments during gameplay and ensure the timer scales appropriately with difficulty. (`[src/actions/sliders.cL30-R37](diffhunk://#diff-c354f4182651779835072db7cc8550855661ead9c2e14a6c6634f947cb10096dL30-R37)`)
* Adjusted the slider for difficulty settings to start at a default value of 0.0 instead of 1.0. (`[includes/inititliser.cL144-R161](diffhunk://#diff-ffe0f8717fd75a777e50621793a924c31e9447d27dfdf1b51a3e7a975be644bdL144-R161)`)

### Miscellaneous Improvements:

* Updated the `draw_item` function to dynamically allocate memory for item names based on the keybind length, improving flexibility. (`[src/raycast/item.cL91-R94](diffhunk://#diff-a252b682ed668d457ece42235f4da315bc7474918fb683ecb5f7e1f4d8ba48aeL91-R94)`)
* Fixed a minor issue in `get_key_name` to handle the end of the key name array more robustly. (`[src/scenes/settings.cL12-R12](diffhunk://#diff-75572b6c55d05cd71df91db15d54e87860b95030d4db88c909099f6bac25ed9dL12-R12)`)…iful score in function of the difficulty, items get and nb ennemies alive (also time):