### PR TITLE
feat (save - load): adding a name for your saves

### DIFF
--- a/includes/frame.h
+++ b/includes/frame.h
@@ -739,6 +739,7 @@ bool load_frame(frame_t *frame, char *save);
 int loads_saved_games(frame_t *frame);
 void free_save(saves_t *saves, frame_t *frame);
 void update_timer(frame_t *frame);
+void create_save_directory(void);
 int check_game_status(frame_t *frame);
 int get_storable_item_count(frame_t *frame);
 

--- a/src/actions/play.c
+++ b/src/actions/play.c
@@ -14,14 +14,66 @@ int do_resume(frame_t *frame)
     return 0;
 }
 
+static bool get_name(frame_t *frame, FILE *fp, char *buffer)
+{
+    char *sswolfs_part = NULL;
+
+    buffer[strcspn(buffer, "\n")] = 0;
+    sswolfs_part = strstr(buffer, "sswolfs/");
+    if (sswolfs_part != NULL) {
+        frame->save = strdup(sswolfs_part);
+    } else {
+        system("zenity --error --text=\"La sauvegarde"
+            " doit être dans le dossier sswolfs/\"");
+        pclose(fp);
+        return false;
+    }
+    frame->name = strdup(sswolfs_part + strlen("sswolfs/"));
+    return true;
+}
+
+static bool get_save_name(frame_t *frame)
+{
+    FILE *fp = popen("zenity --file-selection --save --filename=\"hilter\" "
+        "--title=\"Nom de la partie\"", "r");
+    char buffer[256] = {0};
+
+    if (fp == NULL) {
+        fprintf(stderr, "Failed to run zenity command\n");
+        return -1;
+    }
+    if (fgets(buffer, sizeof(buffer) - 1, fp) != NULL) {
+        if (!get_name(frame, fp, buffer)) {
+            pclose(fp);
+            return get_save_name(frame);
+        }
+        return true;
+    }
+    pclose(fp);
+    return false;
+}
+
+static void check_save(frame_t *frame)
+{
+    if (!frame->played) {
+        create_save_directory();
+        if (get_save_name(frame)) {
+            change_scene(frame, GAME);
+            sfRenderWindow_setMouseCursorVisible(WINDOW, sfFalse);
+            sfMouse_setPositionRenderWindow(v2i(WINDOWX / 2,
+                WINDOWY / 2), WINDOW);
+            frame->played = true;
+        }
+    } else {
+        frame->game->level = 1;
+        change_scene(frame, GAME);
+    }
+}
+
 int do_play(frame_t *frame)
 {
     UI->pause = false;
     PLAYER->pause = false;
-    change_scene(frame, GAME);
-    frame->game->level = 1;
-    frame->played = true;
-    sfRenderWindow_setMouseCursorVisible(WINDOW, sfFalse);
-    sfMouse_setPositionRenderWindow(v2i(WINDOWX / 2, WINDOWY / 2), WINDOW);
+    check_save(frame);
     return 0;
 }

--- a/src/actions/save.c
+++ b/src/actions/save.c
@@ -41,8 +41,7 @@ static void write_save_file(frame_t *frame, FILE *file)
     time(&current_time);
     strftime(game_infos.date, sizeof(game_infos.date), "%Y-%m-%d %H:%M:%S",
         localtime(&current_time));
-    strncpy(game_infos.name, frame->name ? frame->name : "Unknown",
-        sizeof(game_infos.name) - 1);
+    strncpy(game_infos.name, frame->name, sizeof(game_infos.name) - 1);
     fwrite(&game_infos, sizeof(game_infos_t), 1, file);
     write_frame(frame, file);
     fwrite(HUD, sizeof(hud_t), 1, file);
@@ -56,18 +55,7 @@ static void write_save_file(frame_t *frame, FILE *file)
     free(save_image);
 }
 
-static bool save_game(char *save, frame_t *frame)
-{
-    FILE *file = fopen(save, "w");
-
-    if (file == NULL)
-        return false;
-    write_save_file(frame, file);
-    fclose(file);
-    return true;
-}
-
-static void create_save_directory(void)
+void create_save_directory(void)
 {
     struct stat st = {0};
 
@@ -76,23 +64,22 @@ static void create_save_directory(void)
     }
 }
 
-static bool save_new_game(frame_t *frame)
+static bool save_game(frame_t *frame)
 {
     FILE *file = NULL;
-    char *save = NULL;
+    char *save = malloc(sizeof(char) * (strlen(frame->name) +
+        strlen("sswolfs/save-.ww2") + 1));
 
     if (!frame->name)
         frame->name = "EthanLeGrand";
-    save = malloc(sizeof(char) * (strlen(frame->name) +
-        strlen("sswolfs/save-.ww2") + 1));
-    snprintf(save, sizeof(char) * (strlen(frame->name) +
-        strlen("sswolfs/save-.ww2") + 1),
+    snprintf(save, (strlen(frame->name) + strlen("sswolfs/save-.ww2") + 1),
         "sswolfs/save-%s.ww2", frame->name);
     file = fopen(save, "w+");
     if (file == NULL)
         return false;
     write_save_file(frame, file);
     fclose(file);
+    free(save);
     return true;
 }
 
@@ -121,9 +108,5 @@ int do_save(frame_t *frame)
     }
     if (frame->game_over)
         return 0;
-    if (frame->save)
-        return save_game(frame->save, frame);
-    else
-        return save_new_game(frame);
-    return 0;
+    return save_game(frame);
 }

--- a/src/game/load.c
+++ b/src/game/load.c
@@ -119,6 +119,7 @@ static int create_save_button(frame_t *frame, save_info_t *save,
     snprintf(save_info, sizeof(save_info), "%s - %s", save->name, save->date);
     create_text(UI, save_info, sfWhite, v3f(16, pos.x, pos.y + 120));
     frame->game->saves->texts[save_index] = UI->texts[UI->nb_texts - 1];
+    wrap_text(frame->game->saves->texts[save_index].text, 100);
     frame->game->saves->name[save_index] = strdup(save->name);
     applied_button(frame->ui);
     return 0;


### PR DESCRIPTION
This pull request introduces enhancements to the save and load functionality, including improved save handling, directory management, and user interaction for naming saves. It also refactors some related code for better maintainability. Below is a summary of the most important changes:

### Save Handling Improvements:
* Added a new `create_save_directory` function to ensure the save directory exists before saving. This function is now declared in `frame.h` and implemented in `save.c`. [[1]](diffhunk://#diff-2e1d262ba888d8f98fa34922bdab20f39b39436767e3451cfd14379506dddf8cR742) [[2]](diffhunk://#diff-78d180ef924ca2f10371ac82656fd3f3d80546acaa3be29b9a8481b67d9d5839L59-R58)
* Refactored the `save_game` function to dynamically allocate the save file path based on the frame's name, removing redundant code and ensuring proper memory management with `free`.
* Simplified the `do_save` function to always use the updated `save_game` function, removing the distinction between saving new and existing games.

### User Interaction Enhancements:
* Introduced `get_save_name` and `get_name` helper functions to allow users to select or name their save files via a graphical interface (`zenity`), ensuring the save is stored in the correct directory.
* Updated the `do_play` function to check if a save exists before starting the game, prompting the user to create or select a save if necessary.

### Minor Adjustments:
* Removed the fallback "Unknown" name for saves in `write_save_file`, as the frame's name is now guaranteed to be set.
* Added text wrapping for save names in the save button creation process to improve UI readability.