### PR TITLE
fix (save & load): close file 1 time

### DIFF
--- a/src/actions/play.c
+++ b/src/actions/play.c
@@ -25,7 +25,6 @@ static bool get_name(frame_t *frame, FILE *fp, char *buffer)
     } else {
         system("zenity --error --text=\"La sauvegarde"
             " doit être dans le dossier sswolfs/\"");
-        pclose(fp);
         return false;
     }
     frame->name = strdup(sswolfs_part + strlen("sswolfs/"));
@@ -37,16 +36,17 @@ static bool get_save_name(frame_t *frame)
     FILE *fp = popen("zenity --file-selection --save --filename=\"hilter\" "
         "--title=\"Nom de la partie\"", "r");
     char buffer[256] = {0};
+    bool result = false;
 
     if (fp == NULL) {
         fprintf(stderr, "Failed to run zenity command\n");
-        return -1;
+        return false;
     }
     if (fgets(buffer, sizeof(buffer) - 1, fp) != NULL) {
-        if (!get_name(frame, fp, buffer)) {
-            pclose(fp);
+        result = get_name(frame, fp, buffer);
+        pclose(fp);
+        if (!result)
             return get_save_name(frame);
-        }
         return true;
     }
     pclose(fp);


### PR DESCRIPTION
This pull request refactors error handling and return value logic in the `get_save_name` and `get_name` functions in `src/actions/play.c`. The changes improve code clarity and ensure proper resource management.

### Refactoring and Error Handling:

* In `get_save_name`, introduced a `bool result` variable to store the return value of `get_name`. This allows for better readability and more explicit error handling.
* Updated the return value of `get_save_name` to consistently use `false` instead of `-1` for failure, aligning with the function's return type.

### Resource Management:

* Removed an unnecessary `pclose(fp)` call from the `get_name` function, as the file pointer is now consistently closed in `get_save_name`, ensuring proper resource cleanup.