### PR TITLE
fix (warnings): unused parameter in play.c

### DIFF
--- a/src/actions/play.c
+++ b/src/actions/play.c
@@ -14,7 +14,7 @@ int do_resume(frame_t *frame)
     return 0;
 }
 
-static bool get_name(frame_t *frame, FILE *fp, char *buffer)
+static bool get_name(frame_t *frame, char *buffer)
 {
     char *sswolfs_part = NULL;
 
@@ -43,7 +43,7 @@ static bool get_save_name(frame_t *frame)
         return false;
     }
     if (fgets(buffer, sizeof(buffer) - 1, fp) != NULL) {
-        result = get_name(frame, fp, buffer);
+        result = get_name(frame, buffer);
         pclose(fp);
         if (!result)
             return get_save_name(frame);


### PR DESCRIPTION
This pull request simplifies the `get_name` function in `src/actions/play.c` by removing an unused parameter and updating its usage accordingly.

Code simplification:

* [`src/actions/play.c`](diffhunk://#diff-a2d51734138b659565b5170ba6d9ab15de1f0d5650bc50d565e95132ca45e02dL17-R17): Removed the unused `FILE *fp` parameter from the `get_name` function and updated its call site in `get_save_name` to match the new function signature. [[1]](diffhunk://#diff-a2d51734138b659565b5170ba6d9ab15de1f0d5650bc50d565e95132ca45e02dL17-R17) [[2]](diffhunk://#diff-a2d51734138b659565b5170ba6d9ab15de1f0d5650bc50d565e95132ca45e02dL46-R46)